### PR TITLE
Add Scala examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# sbt build artifacts
+/scala-code-examples/target/
+/scala-code-examples/project/target/
+/scala-code-examples/project/project/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 A collection of various small projects
+
+## Scala examples
+
+The `scala-code-examples` directory contains a small sbt project targeting Scala 2.13. To run the tests use:
+
+```bash
+sbt test
+```
+
+If `sbt` isn't available, download the standalone sbt distribution from the [sbt releases](https://github.com/sbt/sbt/releases) page and run `./sbt/bin/sbt test` from this repository root.
+

--- a/scala-code-examples/build.sbt
+++ b/scala-code-examples/build.sbt
@@ -1,0 +1,7 @@
+name := "scala-code-examples"
+
+version := "0.1.0"
+
+scalaVersion := "2.13.12"
+
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % Test

--- a/scala-code-examples/project/build.properties
+++ b/scala-code-examples/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.7

--- a/scala-code-examples/src/main/scala/example/Hello.scala
+++ b/scala-code-examples/src/main/scala/example/Hello.scala
@@ -1,0 +1,5 @@
+package example
+
+object Hello extends App {
+  println("Hello, Scala!")
+}

--- a/scala-code-examples/src/test/scala/example/HelloSpec.scala
+++ b/scala-code-examples/src/test/scala/example/HelloSpec.scala
@@ -1,0 +1,11 @@
+package example
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class HelloSpec extends AnyFlatSpec with Matchers {
+  "Hello" should "print greeting" in {
+    Hello.main(Array.empty)
+    succeed
+  }
+}


### PR DESCRIPTION
## Summary
- add sbt-based Scala example project using Scala 2.13
- include a tiny test and gitignore
- document how to run the Scala examples

## Testing
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_e_68683aea9f2883318aa38d38a36dfb0f